### PR TITLE
Fix headless browser scoring mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
 
                 if (navigator.webdriver) {
                     botScore += 3;
-                    results.push({ check: 'Headless Browser Flag', passed: false, score: 2 });
+                    results.push({ check: 'Headless Browser Flag', passed: false, score: 3 });
                 } else {
                     results.push({ check: 'Headless Browser Flag', passed: true, score: 0 });
                 }


### PR DESCRIPTION
## Summary
- Align displayed headless browser penalty with actual bot score increase

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894651cb040832d8196bd9bd3368821